### PR TITLE
Update Automerge_main.yml to only allow manual merges

### DIFF
--- a/.github/workflows/Automerge_main.yml
+++ b/.github/workflows/Automerge_main.yml
@@ -1,9 +1,6 @@
 name: Automerge staging -> main
 
 on:
-  push:
-    branches:
-      - 'staging'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Changing the process slightly to mimic a standard "deployment" procedure. No more auto merges to main branch.